### PR TITLE
Change "Warrantee" to "Warranty"

### DIFF
--- a/tunic.ps1
+++ b/tunic.ps1
@@ -794,7 +794,7 @@ function gui() {
     $agreeBox.Dock         = [System.Windows.Forms.DockStyle]::Fill
     $agreeBox.text              =
         "I understand this software could cause data loss " +
-        "and is provided as-is without any warrantee.  " +
+        "and is provided as-is without any warranty.  " +
         "I shall not hold the authors liable for any damages whatsoever."
     $agreeBox.AutoSize               = $false
     $agreeBox.height = 50


### PR DESCRIPTION
I've changed the wording of `Warrantee` to `Warranty` to be more grammatically correct.

A `Warranty` is a guarantee of the integrity of a product.
A `Warrantee` is the person to whom a `Warranty` is made.

See [Warrantee](https://www.merriam-webster.com/dictionary/warrantee) and [Warranty](https://www.merriam-webster.com/dictionary/warranty)